### PR TITLE
[Fix]: Request with jwt forbidden

### DIFF
--- a/src/main/java/com/api/oak_store/config/SecurityConfig.java
+++ b/src/main/java/com/api/oak_store/config/SecurityConfig.java
@@ -16,7 +16,7 @@ import org.springframework.security.oauth2.jwt.JwtDecoder;
 import org.springframework.security.oauth2.jwt.JwtEncoder;
 import org.springframework.security.oauth2.jwt.NimbusJwtDecoder;
 import org.springframework.security.oauth2.jwt.NimbusJwtEncoder;
-import org.springframework.security.web.DefaultSecurityFilterChain;
+import org.springframework.security.web.SecurityFilterChain;
 
 import java.security.interfaces.RSAPrivateKey;
 import java.security.interfaces.RSAPublicKey;
@@ -32,7 +32,7 @@ public class SecurityConfig {
     private RSAPrivateKey privateKey;
 
     @Bean
-    public DefaultSecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
 
         http
                 .authorizeHttpRequests(authorize -> authorize
@@ -40,6 +40,11 @@ public class SecurityConfig {
                         .requestMatchers(HttpMethod.POST, "/login").permitAll()
                         .requestMatchers("/swagger-ui/**", "/swagger-ui.html", "/v3/api-docs/**").permitAll()
                         .anyRequest().authenticated()
+                )
+                .oauth2ResourceServer(
+                        oauth2 -> oauth2
+                                .jwt(jwt -> jwt
+                                        .decoder(jwtDecoder()))
                 )
                 .csrf(csrf ->   csrf.disable())
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS));

--- a/src/main/java/com/api/oak_store/controller/UserController.java
+++ b/src/main/java/com/api/oak_store/controller/UserController.java
@@ -43,7 +43,7 @@ public class UserController {
             var expiresIn = 3000L;
 
             var claims = JwtClaimsSet.builder()
-                    .issuer("rest-api-forum")
+                    .issuer("oak-store")
                     .subject(costumer.getCostumerId().toString())
                     .issuedAt(Instant.now())
                     .expiresAt(Instant.now().plusSeconds(expiresIn))

--- a/src/main/java/com/api/oak_store/service/CostumerMapper.java
+++ b/src/main/java/com/api/oak_store/service/CostumerMapper.java
@@ -4,24 +4,31 @@ import com.api.oak_store.controller.dto.CreateCostumerRequest;
 import com.api.oak_store.controller.dto.CostumerResponse;
 import com.api.oak_store.controller.dto.UpdateCostumerRequest;
 import com.api.oak_store.entity.Costumer;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
 @Service
 public class CostumerMapper {
+
+    private final PasswordEncoder passwordEncoder;
+
+    public CostumerMapper(PasswordEncoder passwordEncoder) {
+        this.passwordEncoder = passwordEncoder;
+    }
 
     public Costumer toCostumer(CreateCostumerRequest request) {
         return Costumer.builder()
                 .costumerId(null)
                 .name(request.name())
                 .email(request.email())
-                .password(request.password())
+                .password(passwordEncoder.encode(request.password()))
                 .build();
     }
 
     public void updateCostumerFields(Costumer costumer, UpdateCostumerRequest request) {
         if (request.name() != null) costumer.setName(request.name());
         if (request.email() != null) costumer.setEmail(request.email());
-        if (request.password() != null) costumer.setPassword(request.password());
+        if (request.password() != null) costumer.setPassword(passwordEncoder.encode(request.password()));
     }
 
     public CostumerResponse toCostumerResponse(Costumer costumer) {


### PR DESCRIPTION
## Description
This pull request includes several changes to the security configuration, user authentication, and password encoding in the Oak Store API. The most important changes are summarized below:

## Security Configuration Updates:
* Changed the import from `DefaultSecurityFilterChain` to `SecurityFilterChain` in `SecurityConfig.java`.
* Updated the method signature from `DefaultSecurityFilterChain` to `SecurityFilterChain` in the `securityFilterChain` method.
* Added OAuth2 resource server configuration with JWT decoder in the `securityFilterChain` method.

## User Authentication:
* Modified the JWT issuer from "rest-api-forum" to "oak-store" in the `login` method of `UserController.java`.

## Password Encoding:
* Added `PasswordEncoder` to `CostumerMapper` and updated the `toCostumer` and `updateCostumerFields` methods to encode passwords.